### PR TITLE
MResolve Conflict for PR Allowing deposit of USDC into Aave

### DIFF
--- a/frontend/components/miniSafe/BalanceCard.tsx
+++ b/frontend/components/miniSafe/BalanceCard.tsx
@@ -22,7 +22,7 @@ import {
 const BalanceCard: React.FC = () => {
   const {
     celoBalance,
-    cusdBalance,
+    usdcBalance,
     goodDollarBalance,
     tokenBalance,
     selectedToken,
@@ -91,7 +91,7 @@ const BalanceCard: React.FC = () => {
                   </div>
                   <span className="font-medium">cUSD</span>
                 </div>
-                <div className="text-xl font-bold">{formatBalance(cusdBalance)}</div>
+                <div className="text-xl font-bold">{formatBalance(usdcBalance)}</div>
               </div>
             </div>
 
@@ -146,7 +146,7 @@ const BalanceCard: React.FC = () => {
           </Select>
         </div>
 
-        {parseFloat(cusdBalance) > 0 && (
+        {parseFloat(usdcBalance) > 0 && (
           <Alert className="bg-primary/5 border-primary/20">
             <div className="flex items-start">
               <InfoIcon className="h-5 w-5 text-primary mr-2 mt-0.5" />


### PR DESCRIPTION
This pull request updates the `BalanceCard` component in `frontend/components/miniSafe/BalanceCard.tsx` to replace references to `cusdBalance` with `usdcBalance`. This change reflects a shift from using cUSD (Celo Dollar) to USDC (USD Coin) in the application.

Key changes:

### Balance property updates:
* Replaced the `cusdBalance` property with `usdcBalance` in the destructuring assignment of the balance object. (`[frontend/components/miniSafe/BalanceCard.tsxL25-R25](diffhunk://#diff-8b0b5cb79d0cb20ee72e7a31a6ccc9befa1a4d1b45f901a7855d9b71fc88bad4L25-R25)`)

### UI updates:
* Updated the displayed balance from `cusdBalance` to `usdcBalance` in the balance card UI. (`[frontend/components/miniSafe/BalanceCard.tsxL94-R94](diffhunk://#diff-8b0b5cb79d0cb20ee72e7a31a6ccc9befa1a4d1b45f901a7855d9b71fc88bad4L94-R94)`)
* Modified the conditional rendering logic to check `usdcBalance` instead of `cusdBalance` when determining whether to show the alert. (`[frontend/components/miniSafe/BalanceCard.tsxL149-R149](diffhunk://#diff-8b0b5cb79d0cb20ee72e7a31a6ccc9befa1a4d1b45f901a7855d9b71fc88bad4L149-R149)`)