### PR TITLE
feat: calling ready() to load frames

### DIFF
--- a/farcaster/app/providers.tsx
+++ b/farcaster/app/providers.tsx
@@ -24,14 +24,23 @@ export function AppProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     const load = async () => {
+      try {
       const frameContext = await sdk.context;
       if (!frameContext) {
+        console.warn("No frame context available");
+
         return;
       }
 
       setContext(frameContext as unknown as FrameContext);
       setIsSDKLoaded(true);
+      sdk.actions.ready({});
+    }
+    catch (error) {
+      console.error("Error loading SDK context:", error);
+    }
     };
+    // Check if the SDK is already loaded
     
     if (sdk && !isSDKLoaded) {
       load();


### PR DESCRIPTION
This pull request introduces error handling and logging improvements in the `AppProvider` component to ensure better debugging and stability when loading the SDK context.

### Error handling and logging improvements:
* Added a `try-catch` block around the `load` function to handle potential errors when retrieving the SDK context. If an error occurs, it logs the error message to the console.
* Added a warning log when the `frameContext` is unavailable to help diagnose issues during SDK initialization.
* Ensured the `sdk.actions.ready` method is called after successfully setting the SDK context to signal readiness.