### PR TITLE
feat: integrate the new divvi suffix across all mini apps

### DIFF
--- a/farcaster/context/utilityProvider/ClaimContextProvider.tsx
+++ b/farcaster/context/utilityProvider/ClaimContextProvider.tsx
@@ -28,9 +28,9 @@ const RECIPIENT_WALLET = '0xb82896C4F251ed65186b416dbDb6f6192DFAF926';
 
 // Divvi Integration 
 const dataSuffix = getDataSuffix({
-  consumer: RECIPIENT_WALLET,
-  providers: ['0x5f0a55FaD9424ac99429f635dfb9bF20c3360Ab8', '0x6226ddE08402642964f9A6de844ea3116F0dFc7e'],
-});
+  consumer: '0xb82896C4F251ed65186b416dbDb6f6192DFAF926',
+  providers: ['0x0423189886d7966f0dd7e7d256898daeee625dca'],
+})
 
 // Token definitions
 const TOKENS = {

--- a/farcaster/context/utilityProvider/UtilityContext.tsx
+++ b/farcaster/context/utilityProvider/UtilityContext.tsx
@@ -32,10 +32,9 @@ const RECIPIENT_WALLET = '0xb82896C4F251ed65186b416dbDb6f6192DFAF926';
 
 // Divvi Integration 
 const dataSuffix = getDataSuffix({
-  consumer: RECIPIENT_WALLET,
-  providers: ['0x5f0a55FaD9424ac99429f635dfb9bF20c3360Ab8', '0x6226ddE08402642964f9A6de844ea3116F0dFc7e'],
+  consumer: '0xb82896C4F251ed65186b416dbDb6f6192DFAF926',
+  providers: ['0x0423189886d7966f0dd7e7d256898daeee625dca'],
 })
-
 
 type UtilityContextType = {
   isProcessing: boolean;


### PR DESCRIPTION
This pull request updates the provider addresses used in the Divvi integration for two files in the Farcaster context. The changes ensure that the `consumer` and `providers` values are directly defined inline instead of relying on the `RECIPIENT_WALLET` constant.

### Updates to Divvi Integration:

* [`farcaster/context/utilityProvider/ClaimContextProvider.tsx`](diffhunk://#diff-9dec2dedec9c65c7f5d9bce64c1e66ad8ef4f49b89f9ddd9901a3e8344365651L31-R33): Replaced `RECIPIENT_WALLET` and updated the `providers` array to include a single new address (`'0x0423189886d7966f0dd7e7d256898daeee625dca'`).
* [`farcaster/context/utilityProvider/UtilityContext.tsx`](diffhunk://#diff-6e668021f37a77e873a85e879d5868c6f3ad722380c5aa1e49d95b4e8e498308L35-L39): Replaced `RECIPIENT_WALLET` and updated the `providers` array similarly to the above file.