### PR TITLE
feat: integrate the new data suffix for Divvi

### DIFF
--- a/farcaster/context/utilityProvider/ClaimContextProvider.tsx
+++ b/farcaster/context/utilityProvider/ClaimContextProvider.tsx
@@ -29,9 +29,8 @@ const RECIPIENT_WALLET = '0xb82896C4F251ed65186b416dbDb6f6192DFAF926';
 // Divvi Integration 
 const dataSuffix = getDataSuffix({
   consumer: '0xb82896C4F251ed65186b416dbDb6f6192DFAF926',
-  providers: ['0x0423189886d7966f0dd7e7d256898daeee625dca'],
+  providers: ['0x0423189886d7966f0dd7e7d256898daeee625dca','0xc95876688026be9d6fa7a7c33328bd013effa2bb','0x7beb0e14f8d2e6f6678cc30d867787b384b19e20'],
 })
-
 // Token definitions
 const TOKENS = {
   'G$': {

--- a/frontend/context/miniSafe/MiniSafeContext.tsx
+++ b/frontend/context/miniSafe/MiniSafeContext.tsx
@@ -24,10 +24,10 @@ import {
 import { Button } from "@/components/ui/button";
 import { TransactionSteps, Step, StepStatus } from '@/components/TransactionSteps';
 
-// Divvi Integration
+// Divvi Integration 
 const dataSuffix = getDataSuffix({
   consumer: '0xb82896C4F251ed65186b416dbDb6f6192DFAF926',
-  providers: ['0x0423189886d7966f0dd7e7d256898daeee625dca'],
+  providers: ['0x0423189886d7966f0dd7e7d256898daeee625dca','0xc95876688026be9d6fa7a7c33328bd013effa2bb','0x7beb0e14f8d2e6f6678cc30d867787b384b19e20'],
 })
 
 interface MiniSafeContextType {

--- a/frontend/context/utilityProvider/ClaimContextProvider.tsx
+++ b/frontend/context/utilityProvider/ClaimContextProvider.tsx
@@ -28,7 +28,7 @@ const RECIPIENT_WALLET = '0xb82896C4F251ed65186b416dbDb6f6192DFAF926';
 // Divvi Integration 
 const dataSuffix = getDataSuffix({
   consumer: '0xb82896C4F251ed65186b416dbDb6f6192DFAF926',
-  providers: ['0x0423189886d7966f0dd7e7d256898daeee625dca'],
+  providers: ['0x0423189886d7966f0dd7e7d256898daeee625dca','0xc95876688026be9d6fa7a7c33328bd013effa2bb','0x7beb0e14f8d2e6f6678cc30d867787b384b19e20'],
 })
 
 // Token definitions

--- a/frontend/context/utilityProvider/UtilityContext.tsx
+++ b/frontend/context/utilityProvider/UtilityContext.tsx
@@ -27,9 +27,8 @@ const RECIPIENT_WALLET = '0xb82896C4F251ed65186b416dbDb6f6192DFAF926';
 // Divvi Integration 
 const dataSuffix = getDataSuffix({
   consumer: '0xb82896C4F251ed65186b416dbDb6f6192DFAF926',
-  providers: ['0x0423189886d7966f0dd7e7d256898daeee625dca'],
+  providers: ['0x0423189886d7966f0dd7e7d256898daeee625dca','0xc95876688026be9d6fa7a7c33328bd013effa2bb','0x7beb0e14f8d2e6f6678cc30d867787b384b19e20'],
 })
-
 
 type UtilityContextType = {
   isProcessing: boolean;


### PR DESCRIPTION
This pull request updates the list of provider addresses across multiple files to include additional providers for Divvi integration. These changes ensure consistency and expand the provider set for the `getDataSuffix` function.

### Updates to provider addresses for Divvi integration:

* [`farcaster/context/utilityProvider/ClaimContextProvider.tsx`](diffhunk://#diff-9dec2dedec9c65c7f5d9bce64c1e66ad8ef4f49b89f9ddd9901a3e8344365651L32-L34): Added two new provider addresses (`0xc95876688026be9d6fa7a7c33328bd013effa2bb` and `0x7beb0e14f8d2e6f6678cc30d867787b384b19e20`) to the `providers` array.
* [`frontend/context/miniSafe/MiniSafeContext.tsx`](diffhunk://#diff-377aaababe493efb68969749bf1866c1f3e23c344a2b0f50a9f89c153e0a7df3L30-R30): Updated the `providers` array with the same two new provider addresses for consistency in Divvi integration.
* [`frontend/context/utilityProvider/ClaimContextProvider.tsx`](diffhunk://#diff-7489680cc2381e9bba08f5a32fc88485a3650d17b975473a0c1e8b099d4e6f31L31-R31): Synchronized the `providers` array with the updated list of provider addresses.
* [`frontend/context/utilityProvider/UtilityContext.tsx`](diffhunk://#diff-dcfdd29453a0db441e6ceff07bcbac0bebffc55339029d126403e31d21cf1b1eL30-L33): Modified the `providers` array to include the additional provider addresses, aligning with the changes in other files.