### PR TITLE
fix: fix provider to inject wallet at all times

### DIFF
--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { Alfajores, Celo } from "@celo/rainbowkit-celo/chains";
-import { RainbowKitProvider } from "@rainbow-me/rainbowkit";
+import { RainbowKitProvider, connectorsForWallets } from "@rainbow-me/rainbowkit";
+import { injectedWallet } from "@rainbow-me/rainbowkit/wallets";
 import "@rainbow-me/rainbowkit/styles.css";
 import { WagmiConfig, configureChains, createConfig } from "wagmi";
 import { publicProvider } from "wagmi/providers/public";
@@ -8,9 +9,18 @@ import { ReactNode } from "react";
 import { ClaimProvider } from "@/context/utilityProvider/ClaimContextProvider";
 
 const { chains, publicClient } = configureChains(
-  [Celo, Alfajores],
+  [Celo],
   [publicProvider()]
 );
+
+const connectors = connectorsForWallets([
+  {
+    groupName: 'Recommended',
+    wallets: [
+      injectedWallet({ chains }),
+    ],
+  },
+]);
 
 const appInfo = {
   appName: "Celo Composer",
@@ -18,7 +28,7 @@ const appInfo = {
 
 export const wagmiConfig = createConfig({
   autoConnect: true,
-  connectors: [],
+  connectors,
   publicClient,
 });
 

--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -47,18 +47,21 @@ export default function Header() {
 
   const { isConnected } = useAccount();
   
-  const { connect } = useConnect();
+  const { connect, connectors } = useConnect();
 
   useEffect(() => {
     // Only attempt to connect if not already connected
-    if (!isConnected) {
+    if (!isConnected && connectors.length > 0) {
       try {
-        connect({chainId: Celo.id});
+        const connector = connectors.find((c) => c.id === "injected") || connectors[0];
+        if (connector) {
+          connect({ chainId: Celo.id, connector });
+        }
       } catch (error) {
         console.error("Connection error:", error);
       }
     }
-  }, [connect, isConnected]); 
+  }, [connect, isConnected, connectors]); 
 
   const handleSearchIconClick = () => {
     setSearchVisible(true);


### PR DESCRIPTION
This pull request updates wallet connection functionality in the frontend codebase to improve user experience and streamline wallet integration. Key changes include introducing connectors for wallets, removing the Alfajores testnet chain, and enhancing the connection logic in the `Header` component.

### Wallet Integration Enhancements:

* [`frontend/app/providers.tsx`](diffhunk://#diff-8677b3d87b65f6c01af41123cacd46763fed62d52bbed1cb322eb89891142153L3-R31): Added support for wallet connectors using `connectorsForWallets` and configured the `injectedWallet` for the Celo chain. Removed the Alfajores testnet chain from the configuration.

### Connection Logic Improvements:

* [`frontend/components/Header.tsx`](diffhunk://#diff-009d116c8c98b6300b198b32a59f670c3bf55c2877e4c81a3061fac2806b8540L50-R64): Updated the connection logic to dynamically select and use the appropriate wallet connector, ensuring fallback behavior if the "injected" connector is unavailable. Added a check for the presence of connectors before attempting to connect.