### PR TITLE
refactor: reduce usdt gas sponsorship by 6 after bypassing thirdweb b…

### DIFF
--- a/backend/lib/services/gasSponsorshipService.ts
+++ b/backend/lib/services/gasSponsorshipService.ts
@@ -13,7 +13,7 @@ const config = {
     maxAmountCELO: parseFloat(process.env.GAS_SPONSORSHIP_MAX_AMOUNT_CELO || '0.1'),
     cooldownMinutes: parseInt(process.env.GAS_SPONSORSHIP_COOLDOWN_MINUTES || '0'),
     lowBalanceThreshold: parseFloat(process.env.GAS_SPONSORSHIP_LOW_BALANCE_THRESHOLD || '100'),
-    celoUsdPrice: parseFloat(process.env.CELO_USD_PRICE || '0.6'),
+    celoUsdPrice: parseFloat(process.env.CELO_USD_PRICE || '0.1'),
 };
 
 // USDT on Celo — whitelisted as a gas fee currency


### PR DESCRIPTION
This pull request makes a minor configuration change to the gas sponsorship service. The only update is to lower the default value of the `celoUsdPrice` environment variable from 0.6 to 0.1.

* Reduced the default value for `celoUsdPrice` in `backend/lib/services/gasSponsorshipService.ts` from 0.6 to 0.1.…ased tx for utilities